### PR TITLE
Fix: Add CORS headers to .htaccess file for error resolution

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -4,3 +4,10 @@ RewriteBase /
 RewriteCond %{THE_REQUEST} public/([^\s?]*) [NC]
 RewriteRule ^ %1 [L,NE,R=302]
 RewriteRule ^((?!public/).*)$ /public/$1 [L,NC]
+
+<IfModule mod_headers.c>
+    Header add Access-Control-Allow-Origin "*"
+    Header set Access-Control-Allow-Methods "GET, POST, OPTIONS, PUT, DELETE"
+    Header set Access-Control-Allow-Headers "Content-Type, Authorization, X-Requested-With, no-auth"
+    Header set Access-Control-Allow-Credentials "true"
+</IfModule>


### PR DESCRIPTION
This commit adds essential CORS (Cross-Origin Resource Sharing) headers to the .htaccess file to address the CORS-related error. Each header serves a specific purpose in allowing controlled access to resources on the server from different origins:

1. Header add Access-Control-Allow-Origin "*"

Purpose: This header specifies which origins are allowed to access the resources on the server. In this case, the wildcard "*" allows any origin to access the resources. Alternatively, you could specify specific origins like "https://example.com" to limit access to only that domain.

2. Header set Access-Control-Allow-Methods "GET, POST, OPTIONS, PUT, DELETE"

Purpose: This header defines the HTTP methods that are allowed when making requests to the server. In this case, the specified methods are GET, POST, OPTIONS, PUT, and DELETE, enabling clients to perform these actions on the server's resources.

3. Header set Access-Control-Allow-Headers "Content-Type, Authorization, X-Requested-With, no-auth"

Purpose: This header lists the HTTP request headers that are permitted during a CORS request. It includes "Content-Type" (used to specify the content type of the request payload), "Authorization" (used for authentication purposes), "X-Requested-With" (often used by JavaScript libraries), and "no-auth" (a custom header that may be used for application-specific purposes).

4. Header set Access-Control-Allow-Credentials "true"

Purpose: This header indicates whether the client can send credentials (e.g., cookies, HTTP authentication) in the CORS request. By setting it to "true," the server allows credentials to be included, which is necessary when making authenticated requests. By adding these headers to the .htaccess file, the server will now respond to CORS requests correctly, and clients from different origins will be able to access the specified resources without encountering CORS-related errors.